### PR TITLE
Start Docker in setup

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -15,13 +15,11 @@ apt-get install -y --no-install-recommends \
     findutils \
     openjdk-11-jre-headless
 
-# Pre-pull container images used in the README steps
 
-#docker pull python:3.6
-
-#docker pull python:3.7
-
-#docker pull maven:3.8-openjdk-11
-
-#docker pull vespaengine/vespa
+# Start the Docker daemon and pre-pull container images so that tests
+# depending on Docker can run without requiring network access.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$SCRIPT_DIR/init.sh" ]; then
+    bash "$SCRIPT_DIR/init.sh"
+fi
 

--- a/tests/test_readme.sh
+++ b/tests/test_readme.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure Docker is available. Attempt to start it using the repo's init script
+# if `docker info` fails. Fail the test if Docker still isn't available so that
+# README steps always execute when possible.
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+if ! docker info >/dev/null 2>&1; then
+    if [ -x "$REPO_DIR/codex/init.sh" ]; then
+        bash "$REPO_DIR/codex/init.sh" || true
+    fi
+    if ! docker info >/dev/null 2>&1; then
+        echo "Docker daemon not available; failing README integration test." >&2
+        exit 1
+    fi
+fi
+
 # Integration test that follows the README instructions
 # Start Vespa and model servers using Docker
 bin/deploy_servers.sh


### PR DESCRIPTION
## Summary
- start Docker and pre-pull images from `codex/setup.sh`
- fail the README test when Docker cannot start

## Testing
- `bash tests/test_readme.sh` *(fails: Docker daemon not available)*