### PR TITLE
Skip pip install on every transform run

### DIFF
--- a/transform/transform.sh
+++ b/transform/transform.sh
@@ -3,14 +3,19 @@ set -euo pipefail
 
 # 1. Activate (or create) a local virtual environment -------------------------
 VENV_DIR=".venv"
+CREATED_ENV=false
 if [[ ! -d "$VENV_DIR" ]]; then
   python -m venv "$VENV_DIR"
+  CREATED_ENV=true
 fi
 # shellcheck source=/dev/null
 source "$VENV_DIR/bin/activate"
 
-# 2. Keep tools up to date, but inside the venv --------------------------------
-python -m pip install --upgrade pip sentence-transformers
+# 2. Install dependencies only when the venv is first created ------------------
+if [[ "$CREATED_ENV" == true ]]; then
+  python -m pip install --upgrade pip
+  python -m pip install sentence-transformers
+fi
 
 # 3. Convert every CSV safely --------------------------------------------------
 shopt -s nullglob                 # empty glob ⇒ empty list, not the literal pattern


### PR DESCRIPTION
## Summary
- create the virtualenv if needed
- only install Python dependencies when the venv is first created

## Testing
- `python -m py_compile transform/csv_to_vespa_json.py`
- `shellcheck transform/transform.sh` *(fails: command not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc0961470832aaa960fd8c62e0086