### PR TITLE
Improve ranking mode UI

### DIFF
--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -162,7 +162,7 @@ top_k = st.slider(
     label_visibility="collapsed"         # keep label hidden if you like
 )
 
-# ── Ranking mode table ──────────────────────────────────────────────────────
+# ── Ranking modes ───────────────────────────────────────────────────────────
 RANKINGS = [
     (
         "Vector",
@@ -176,17 +176,10 @@ ranking_idx = st.radio(
     "Ranking mode",
     options=list(range(len(RANKINGS))),
     format_func=lambda i: RANKINGS[i][0],
+    horizontal=True,
 )
-ranking = RANKINGS[ranking_idx][0]
-
-header = st.columns([3, 7])
-header[0].markdown("**Mode**")
-header[1].markdown("**Expression**")
-for i, (name, expr) in enumerate(RANKINGS):
-    cols = st.columns([3, 7])
-    bullet = "&#9679;" if i == ranking_idx else "&#9711;"
-    cols[0].markdown(f"{bullet} {name}", unsafe_allow_html=True)
-    cols[1].code(expr, language="")
+ranking, ranking_expr = RANKINGS[ranking_idx]
+st.code(ranking_expr, language="")
 
 if q:
     try:


### PR DESCRIPTION
## Summary
- update ranking mode section to show options horizontally
- show expression for chosen ranking profile only

## Testing
- `python3 -m py_compile ui/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687105feabf8832a925027ad51cf049d